### PR TITLE
#20

### DIFF
--- a/src/config/actions/game.js
+++ b/src/config/actions/game.js
@@ -14,4 +14,5 @@ export const GAME = {
   GET_LOSE: `${domain}:get_lose`,
   WINNER: `${domain}:winner`,
   RESPONSE: `${domain}:response`,
+  LEAVER: `${domain}:leaver`,
 };

--- a/src/config/actions/game.js
+++ b/src/config/actions/game.js
@@ -14,5 +14,4 @@ export const GAME = {
   GET_LOSE: `${domain}:get_lose`,
   WINNER: `${domain}:winner`,
   RESPONSE: `${domain}:response`,
-  LEAVER: `${domain}:leaver`,
 };

--- a/src/config/actions/game.js
+++ b/src/config/actions/game.js
@@ -1,0 +1,16 @@
+const domain = "game";
+export default domain;
+
+export const GAME = {
+  START: `${domain}:start`,
+  STARTED: `${domain}:started`,
+  SEND_BOARD: `${domain}:send_board`,
+  GET_BOARD: `${domain}:get_board`,
+  SEND_SCORE: `${domain}:send_score`,
+  GET_SCORE: `${domain}:get_score`,
+  SEND_PENALTY: `${domain}:send_penalty`,
+  GET_PENALTY: `${domain}:get_penalty`,
+  SEND_LOSE: `${domain}:send_lose`,
+  GET_LOSE: `${domain}:get_lose`,
+  WINNER: `${domain}:winner`,
+};

--- a/src/config/actions/game.js
+++ b/src/config/actions/game.js
@@ -13,4 +13,5 @@ export const GAME = {
   SEND_LOSE: `${domain}:send_lose`,
   GET_LOSE: `${domain}:get_lose`,
   WINNER: `${domain}:winner`,
+  RESPONSE: `${domain}:response`,
 };

--- a/src/config/actions/lobby.js
+++ b/src/config/actions/lobby.js
@@ -7,5 +7,6 @@ export const LOBBY = {
   UPDATE: `${domain}:update`,
   PUBLISH: `${domain}:publish`,
   RESPONSE: `${domain}:response`,
+  READY: `${domain}:ready`,
   LEAVER: `${domain}:leaver`,
 };

--- a/src/config/actions/lobby.js
+++ b/src/config/actions/lobby.js
@@ -7,4 +7,5 @@ export const LOBBY = {
   UPDATE: `${domain}:update`,
   PUBLISH: `${domain}:publish`,
   RESPONSE: `${domain}:response`,
+  LEAVER: `${domain}:leaver`,
 };

--- a/src/server/listeners/events.js
+++ b/src/server/listeners/events.js
@@ -20,6 +20,7 @@ export default {
     clear: "onClearRoom",
   },
   game: {
+    started: "onGameStarted",
     board: "onBoardChange",
     penalty: "onPenalty",
     score: "onScoreChange",

--- a/src/server/listeners/events.js
+++ b/src/server/listeners/events.js
@@ -18,6 +18,7 @@ export default {
   },
   room: {
     clear: "onClearRoom",
+    join: "onJoinRoom",
   },
   game: {
     started: "onGameStarted",

--- a/src/server/listeners/events.js
+++ b/src/server/listeners/events.js
@@ -21,9 +21,9 @@ export default {
   },
   game: {
     started: "onGameStarted",
+    score: "onScoreChange",
     board: "onBoardChange",
     penalty: "onPenalty",
-    score: "onScoreChange",
     lose: "onLose",
     winner: "onWinner",
   },

--- a/src/server/listeners/events.js
+++ b/src/server/listeners/events.js
@@ -5,6 +5,7 @@ export default {
   },
   lobby: {
     change: "onLobbyChange",
+    leaver: "onLobbyLeaver",
   },
   players: {
     change: "onPlayersChange",
@@ -17,5 +18,12 @@ export default {
   },
   room: {
     clear: "onClearRoom",
+  },
+  game: {
+    board: "onBoardChange",
+    penalty: "onPenalty",
+    score: "onScoreChange",
+    lose: "onLose",
+    winner: "onWinner",
   },
 };

--- a/src/server/listeners/index.js
+++ b/src/server/listeners/index.js
@@ -86,6 +86,11 @@ eventEmitter.on(event.room.clear, async ({ room }) => {
   });
 });
 
+// Game Started
+eventEmitter.on(event.game.started, ({ lobbyId, game }) => {
+  io.in(`${GROUP_DOMAIN}:${lobbyId}`).emit(GAME.STARTED, game);
+});
+
 // Game Board Change
 eventEmitter.on(event.game.board, ({ socket, lobbyId, boardGame }) => {
   const socketId = socket.id;

--- a/src/server/listeners/index.js
+++ b/src/server/listeners/index.js
@@ -91,56 +91,51 @@ eventEmitter.on(event.game.started, ({ lobbyId, game }) => {
   io.in(`${GROUP_DOMAIN}:${lobbyId}`).emit(GAME.STARTED, game);
 });
 
+// Game Score Change
+eventEmitter.on(event.game.board, ({ socket, playerId, lobbyId, score }) => {
+  socket.broadcast
+    .to(`${GROUP_DOMAIN}:${lobbyId}`)
+    .emit(GAME.GET_SCORE, { playerId, score });
+});
+
 // Game Board Change
-eventEmitter.on(event.game.board, ({ socket, lobbyId, boardGame }) => {
-  const socketId = socket.id;
-  socket.broadcast
-    .to(`${GROUP_DOMAIN}:${lobbyId}`)
-    .emit(GAME.GET_BOARD, { socketId, boardGame });
-});
+eventEmitter.on(
+  event.game.board,
+  ({ socket, playerId, lobbyId, boardGame }) => {
+    socket.broadcast
+      .to(`${GROUP_DOMAIN}:${lobbyId}`)
+      .emit(GAME.GET_BOARD, { playerId, boardGame });
+  },
+);
 
 // Game Penalty
-eventEmitter.on(event.game.penalty, ({ socket, lobbyId, nbLinePenalty }) => {
-  const socketId = socket.id;
-  socket.broadcast
-    .to(`${GROUP_DOMAIN}:${lobbyId}`)
-    .emit(GAME.GET_PENALTY, { socketId, nbLinePenalty });
-});
-
-// Game Penalty
-// TODO
-eventEmitter.on(event.game.score, ({ socket, lobbyId, score }) => {
-  const socketId = socket.id;
-  socket.broadcast
-    .to(`${GROUP_DOMAIN}:${lobbyId}`)
-    .emit(GAME.GET_SCORE, { socketId, score });
-});
+eventEmitter.on(
+  event.game.penalty,
+  ({ socket, playerId, lobbyId, nbLinePenalty }) => {
+    socket.broadcast
+      .to(`${GROUP_DOMAIN}:${lobbyId}`)
+      .emit(GAME.GET_PENALTY, { playerId, nbLinePenalty });
+  },
+);
 
 // Game Lose
-// TODO
-eventEmitter.on(event.game.lose, ({ socket, lobbyId }) => {
-  const socketId = socket.id;
+eventEmitter.on(event.game.lose, ({ socket, playerId, lobbyId }) => {
   socket.broadcast
     .to(`${GROUP_DOMAIN}:${lobbyId}`)
-    .emit(GAME.GET_LOSE, { socketId });
+    .emit(GAME.GET_LOSE, { playerId });
 });
 
 // Game Winner
-// TODO
-eventEmitter.on(event.game.winner, ({ socket, score }) => {
-  const socketId = socket.id;
-  // socket.broadcast
-  //   .to(`${GROUP_DOMAIN}:${lobbyId}`)
-  //   .emit(GAME.WINNER, { socketId, score });
-  io.in(`${GROUP_DOMAIN}:${lobbyId}`).emit(GAME.WINNER, { socketId, score });
+eventEmitter.on(event.game.winner, ({ playerId, score }) => {
+  io.in(`${GROUP_DOMAIN}:${lobbyId}`).emit(GAME.WINNER, { playerId, score });
 });
 
-// Lobby Leaver
-// TODO
-eventEmitter.on(event.game.leaver, ({ socketId }) => {
-  socket.broadcast
-    .to(`${GROUP_DOMAIN}:${lobbyId}`)
-    .emit(LOBBY.LEAVER, { socketId });
-});
+// // Lobby Leaver
+// // TODO
+// eventEmitter.on(event.game.leaver, ({ socketId }) => {
+//   socket.broadcast
+//     .to(`${GROUP_DOMAIN}:${lobbyId}`)
+//     .emit(LOBBY.LEAVER, { socketId });
+// });
 
 export default eventEmitter;

--- a/src/server/listeners/index.js
+++ b/src/server/listeners/index.js
@@ -5,6 +5,7 @@ import { LOBBIES } from "../../config/actions/lobbies";
 import { LOBBY } from "../../config/actions/lobby";
 import { PLAYERS } from "../../config/actions/players";
 import { MESSAGE } from "../../config/actions/message";
+import { GAME } from "../../config/actions/game";
 import GROUP_DOMAIN, { GROUP } from "../../config/actions/group";
 import { getLobby, clearPlayerFromLobbies } from "storage/lobbies";
 import { popPlayer, getPlayerId } from "storage/players";
@@ -83,6 +84,58 @@ eventEmitter.on(event.room.clear, async ({ room }) => {
       });
     }
   });
+});
+
+// Game Board Change
+eventEmitter.on(event.game.board, ({ socket, lobbyId, boardGame }) => {
+  const socketId = socket.id;
+  socket.broadcast
+    .to(`${GROUP_DOMAIN}:${lobbyId}`)
+    .emit(GAME.GET_BOARD, { socketId, boardGame });
+});
+
+// Game Penalty
+eventEmitter.on(event.game.penalty, ({ socket, lobbyId, nbLinePenalty }) => {
+  const socketId = socket.id;
+  socket.broadcast
+    .to(`${GROUP_DOMAIN}:${lobbyId}`)
+    .emit(GAME.GET_PENALTY, { socketId, nbLinePenalty });
+});
+
+// Game Penalty
+// TODO
+eventEmitter.on(event.game.score, ({ socket, lobbyId, score }) => {
+  const socketId = socket.id;
+  socket.broadcast
+    .to(`${GROUP_DOMAIN}:${lobbyId}`)
+    .emit(GAME.GET_SCORE, { socketId, score });
+});
+
+// Game Lose
+// TODO
+eventEmitter.on(event.game.lose, ({ socket, lobbyId }) => {
+  const socketId = socket.id;
+  socket.broadcast
+    .to(`${GROUP_DOMAIN}:${lobbyId}`)
+    .emit(GAME.GET_LOSE, { socketId });
+});
+
+// Game Winner
+// TODO
+eventEmitter.on(event.game.winner, ({ socket, score }) => {
+  const socketId = socket.id;
+  // socket.broadcast
+  //   .to(`${GROUP_DOMAIN}:${lobbyId}`)
+  //   .emit(GAME.WINNER, { socketId, score });
+  io.in(`${GROUP_DOMAIN}:${lobbyId}`).emit(GAME.WINNER, { socketId, score });
+});
+
+// Lobby Leaver
+// TODO
+eventEmitter.on(event.game.leaver, ({ socketId }) => {
+  socket.broadcast
+    .to(`${GROUP_DOMAIN}:${lobbyId}`)
+    .emit(LOBBY.LEAVER, { socketId });
 });
 
 export default eventEmitter;

--- a/src/server/listeners/index.js
+++ b/src/server/listeners/index.js
@@ -71,8 +71,8 @@ eventEmitter.on(event.player.disconnect, async ({ socket }) => {
 });
 
 // Message new
-eventEmitter.on(event.message.new, async ({ socket, messageObject }) => {
-  io.in(GROUP.LOBBIES).emit(MESSAGE.PUBLISH, messageObject);
+eventEmitter.on(event.message.new, async ({ lobbyId, messageObject }) => {
+  io.in(`${GROUP_DOMAIN}:${lobbyId}`).emit(MESSAGE.PUBLISH, messageObject);
 });
 
 // Clear Room

--- a/src/server/models/game.js
+++ b/src/server/models/game.js
@@ -1,6 +1,24 @@
+import { nanoid } from "nanoid";
+
+const createPlayers = (players) => {
+  const newPlayers = [];
+  players.forEach((element) => {
+    newPlayers.push({
+      player: element.player,
+      score: 0,
+      loser: false,
+      board: [],
+    });
+  });
+  return newPlayers;
+};
+
 export default class Game {
-  constructor({ id, name }) {
-    this.id = id;
+  constructor({ name, owner, players }) {
+    this.id = nanoid();
     this.name = name;
+    this.over = false;
+    this.players = createPlayers(players);
+    this.owner = owner;
   }
 }

--- a/src/server/models/game.js
+++ b/src/server/models/game.js
@@ -7,7 +7,7 @@ const createPlayers = (players) => {
       player: element.player,
       score: 0,
       loser: false,
-      board: [],
+      // board: [],
     });
   });
   return newPlayers;

--- a/src/server/models/lobby.js
+++ b/src/server/models/lobby.js
@@ -6,6 +6,7 @@ export default class Lobby {
     this.hash = hash;
     this.name = name;
     this.maxPlayer = maxPlayer;
+    this.isPlaying = false;
     this.players = [];
     this.owner = owner;
   }

--- a/src/server/socket/disconnect/handlers.js
+++ b/src/server/socket/disconnect/handlers.js
@@ -1,7 +1,6 @@
 import { logerror, loginfo } from "utils/log";
 import eventEmitter from "listeners";
 import event from "listeners/events";
-import { clearPlayerFromLobbies } from "storage/lobbies";
 
 export const handlerOnDisconnect = async (socket, reason) => {
   loginfo(socket.id, "disconnect with reason", reason);

--- a/src/server/socket/game/handlers.js
+++ b/src/server/socket/game/handlers.js
@@ -1,6 +1,6 @@
 import { logerror, loginfo } from "utils/log";
-import { getPlayer } from "store/players";
-import { joinLobby, leaveLobby } from "store/lobbies";
+import { getPlayer } from "storage/players";
+import { joinLobby, leaveLobby } from "storage/lobbies";
 import { LOBBY } from "../../../config/actions/lobby";
 import GROUP_DOMAIN from "../../../config/actions/group";
 import eventEmitter from "listeners";

--- a/src/server/socket/game/handlers.js
+++ b/src/server/socket/game/handlers.js
@@ -28,7 +28,7 @@ export const handlerStartGame = async (socket, { lobbyId, ownerId }) => {
       owner: lobby.owner,
       players: lobby.players,
     });
-    setGame(game);
+    await setGame(game);
 
     eventEmitter.emit(event.game.started, {
       lobbyId,
@@ -37,35 +37,41 @@ export const handlerStartGame = async (socket, { lobbyId, ownerId }) => {
   }
 };
 
-export const handlerSendBoard = (socket, { lobbyId, boardGame }) => {
-  eventEmitter.emit(event.game.board, {
-    socket,
-    lobbyId,
-    boardGame,
-  });
-};
-
-export const handlerSendPenalty = (socket, { lobbyId, nbLinePenalty }) => {
-  eventEmitter.emit(event.game.penalty, {
-    socket,
-    lobbyId,
-    nbLinePenalty,
-  });
-};
-
-// TODO
-export const handlerSendScore = (socket, { lobbyId, score }) => {
+export const handlerSendScore = async (socket, { gameId, playerId, score }) => {
+  await updateScore(gameId, playerId, score);
   eventEmitter.emit(event.game.score, {
     socket,
+    playerId,
     lobbyId,
     score,
   });
 };
 
-// TODO
-export const handlerSendLose = (socket, { lobbyId }) => {
+export const handlerSendBoard = (socket, { lobbyId, playerId, boardGame }) => {
+  eventEmitter.emit(event.game.board, {
+    socket,
+    playerId,
+    lobbyId,
+    boardGame,
+  });
+};
+
+export const handlerSendPenalty = (
+  socket,
+  { lobbyId, playerId, nbLinePenalty },
+) => {
+  eventEmitter.emit(event.game.penalty, {
+    socket,
+    playerId,
+    lobbyId,
+    nbLinePenalty,
+  });
+};
+
+export const handlerSendLose = (socket, { lobbyId, playerId }) => {
   eventEmitter.emit(event.game.lose, {
     socket,
+    playerId,
     lobbyId,
   });
 };

--- a/src/server/socket/game/handlers.js
+++ b/src/server/socket/game/handlers.js
@@ -1,0 +1,40 @@
+import { logerror, loginfo } from "utils/log";
+import { getPlayer } from "store/players";
+import { joinLobby, leaveLobby } from "store/lobbies";
+import { LOBBY } from "../../../config/actions/lobby";
+import GROUP_DOMAIN from "../../../config/actions/group";
+import eventEmitter from "listeners";
+import event from "listeners/events";
+
+export const handlerSendBoard = (socket, { lobbyId, boardGame }) => {
+  eventEmitter.emit(event.game.board, {
+    socket,
+    lobbyId,
+    boardGame,
+  });
+};
+
+export const handlerSendPenalty = (socket, { lobbyId, nbLinePenalty }) => {
+  eventEmitter.emit(event.game.penalty, {
+    socket,
+    lobbyId,
+    nbLinePenalty,
+  });
+};
+
+// TODO
+export const handlerSendScore = (socket, { lobbyId, score }) => {
+  eventEmitter.emit(event.game.score, {
+    socket,
+    lobbyId,
+    score,
+  });
+};
+
+// TODO
+export const handlerSendLose = (socket, { lobbyId }) => {
+  eventEmitter.emit(event.game.lose, {
+    socket,
+    lobbyId,
+  });
+};

--- a/src/server/socket/game/handlers.js
+++ b/src/server/socket/game/handlers.js
@@ -1,10 +1,20 @@
 import { logerror, loginfo } from "utils/log";
-import { getPlayer } from "storage/players";
-import { joinLobby, leaveLobby } from "storage/lobbies";
-import { LOBBY } from "../../../config/actions/lobby";
-import GROUP_DOMAIN from "../../../config/actions/group";
+import { startGame } from "storage/lobbies";
+import { GAME } from "../../../config/actions/game";
 import eventEmitter from "listeners";
 import event from "listeners/events";
+
+export const handlerStartGame = async (socket, { lobbyId, playerId }) => {
+  const response = await startGame(playerId, lobbyId);
+  socket.emit(GAME.RESPONSE, response);
+
+  // if (response.type === "success") {
+  //   eventEmitter.emit(event.lobby.change, {
+  //     socket,
+  //     lobbyId,
+  //   });
+  // }
+};
 
 export const handlerSendBoard = (socket, { lobbyId, boardGame }) => {
   eventEmitter.emit(event.game.board, {

--- a/src/server/socket/game/handlers.js
+++ b/src/server/socket/game/handlers.js
@@ -4,7 +4,12 @@ import { GAME } from "../../../config/actions/game";
 import Game from "models/game";
 import eventEmitter from "listeners";
 import event from "listeners/events";
-import { setGame } from "../../storage/game";
+import {
+  setGame,
+  updateScore,
+  checkForWinner,
+  setLoser,
+} from "../../storage/game";
 
 export const handlerStartGame = async (socket, { lobbyId, ownerId }) => {
   const response = await startGame(ownerId, lobbyId);
@@ -45,6 +50,7 @@ export const handlerSendScore = async (socket, { gameId, playerId, score }) => {
     lobbyId,
     score,
   });
+  checkForWinner(gameId);
 };
 
 export const handlerSendBoard = (socket, { lobbyId, playerId, boardGame }) => {
@@ -68,10 +74,12 @@ export const handlerSendPenalty = (
   });
 };
 
-export const handlerSendLose = (socket, { lobbyId, playerId }) => {
+export const handlerSendLose = async (socket, { lobbyId, playerId }) => {
+  await setLoser(gameId, playerId);
   eventEmitter.emit(event.game.lose, {
     socket,
     playerId,
     lobbyId,
   });
+  checkForWinner(gameId);
 };

--- a/src/server/socket/game/handlers.js
+++ b/src/server/socket/game/handlers.js
@@ -1,4 +1,5 @@
 import { logerror, loginfo } from "utils/log";
+import { deleteKeyFromRedis } from "storage";
 import { startGame, getLobby } from "storage/lobbies";
 import { GAME } from "../../../config/actions/game";
 import Game from "models/game";
@@ -47,39 +48,52 @@ export const handlerSendScore = async (socket, { gameId, playerId, score }) => {
   eventEmitter.emit(event.game.score, {
     socket,
     playerId,
-    lobbyId,
+    gameId,
     score,
   });
-  checkForWinner(gameId);
+  checkWinner(gameId);
 };
 
-export const handlerSendBoard = (socket, { lobbyId, playerId, boardGame }) => {
+export const handlerSendBoard = (socket, { gameId, playerId, boardGame }) => {
   eventEmitter.emit(event.game.board, {
     socket,
     playerId,
-    lobbyId,
+    gameId,
     boardGame,
   });
 };
 
 export const handlerSendPenalty = (
   socket,
-  { lobbyId, playerId, nbLinePenalty },
+  { gameId, playerId, nbLinePenalty },
 ) => {
   eventEmitter.emit(event.game.penalty, {
     socket,
     playerId,
-    lobbyId,
+    gameId,
     nbLinePenalty,
   });
 };
 
-export const handlerSendLose = async (socket, { lobbyId, playerId }) => {
+export const handlerSendLose = async (socket, { gameId, playerId }) => {
   await setLoser(gameId, playerId);
   eventEmitter.emit(event.game.lose, {
     socket,
     playerId,
-    lobbyId,
+    gameId,
   });
-  checkForWinner(gameId);
+  checkWinner(gameId);
+};
+
+const checkWinner = async (gameId) => {
+  const winner = await checkForWinner(gameId);
+
+  if (winner) {
+    eventEmitter.emit(event.game.winner, {
+      gameId,
+      winner,
+    });
+    // delete game object?
+    deleteKeyFromRedis(`game-${gameId}`);
+  }
 };

--- a/src/server/socket/game/index.js
+++ b/src/server/socket/game/index.js
@@ -1,4 +1,4 @@
-import { createEvent } from "helpers/socket";
+import { createEvent } from "socket/helpers/socket";
 import {
   validationSendBoard,
   validationSendPenalty,

--- a/src/server/socket/game/index.js
+++ b/src/server/socket/game/index.js
@@ -1,17 +1,25 @@
 import { createEvent } from "socket/helpers/socket";
 import {
+  validationStartGame,
   validationSendBoard,
   validationSendPenalty,
   validationSendScore,
   validationSendLose,
 } from "socket/game/schemas";
 import {
+  handlerStartGame,
   handlerSendBoard,
   handlerSendPenalty,
   handlerSendScore,
   handlerSendLose,
 } from "socket/game/handlers";
 import { GAME } from "./../../../config/actions/game";
+
+export const startGame = createEvent(
+  GAME.START,
+  validationStartGame,
+  handlerStartGame,
+);
 
 export const sendBoard = createEvent(
   GAME.SEND_BOARD,

--- a/src/server/socket/game/index.js
+++ b/src/server/socket/game/index.js
@@ -1,0 +1,38 @@
+import { createEvent } from "helpers/socket";
+import {
+  validationSendBoard,
+  validationSendPenalty,
+  validationSendScore,
+  validationSendLose,
+} from "socket/game/schemas";
+import {
+  handlerSendBoard,
+  handlerSendPenalty,
+  handlerSendScore,
+  handlerSendLose,
+} from "socket/game/handlers";
+import { GAME } from "./../../../config/actions/game";
+
+export const sendBoard = createEvent(
+  GAME.SEND_BOARD,
+  validationSendBoard,
+  handlerSendBoard,
+);
+
+export const sendPenalty = createEvent(
+  GAME.SEND_PENALTY,
+  validationSendPenalty,
+  handlerSendPenalty,
+);
+
+export const sendScore = createEvent(
+  GAME.SEND_SCORE,
+  validationSendScore,
+  handlerSendScore,
+);
+
+export const sendLose = createEvent(
+  GAME.SEND_LOSE,
+  validationSendLose,
+  handlerSendLose,
+);

--- a/src/server/socket/game/schemas.js
+++ b/src/server/socket/game/schemas.js
@@ -1,5 +1,10 @@
 import Joi from "joi";
 
+export const validationStartGame = {
+  lobbyId: Joi.string().required().description("The id of the lobby"),
+  playerId: Joi.string().required().description("The id of the player"),
+};
+
 export const validationSendBoard = {
   lobbyId: Joi.string().required().description("The id of the lobby"),
   boardGame: Joi.array().required().description("The boardGame of the player"),

--- a/src/server/socket/game/schemas.js
+++ b/src/server/socket/game/schemas.js
@@ -1,0 +1,20 @@
+import Joi from "joi";
+
+export const validationSendBoard = {
+  lobbyId: Joi.string().required().description("The id of the lobby"),
+  boardGame: Joi.array().required().description("The boardGame of the player"),
+};
+
+export const validationSendPenalty = {
+  lobbyId: Joi.string().required().description("The id of the lobby"),
+  nbLinePenalty: Joi.number().required().description("The nb of penalty lines"),
+};
+
+export const validationSendScore = {
+  lobbyId: Joi.string().required().description("The id of the lobby"),
+  score: Joi.number().required().description("The score of the player"),
+};
+
+export const validationSendLose = {
+  lobbyId: Joi.string().required().description("The id of the lobby"),
+};

--- a/src/server/socket/index.js
+++ b/src/server/socket/index.js
@@ -8,6 +8,7 @@ import * as lobbies from "socket/lobbies";
 import * as lobby from "socket/lobby";
 import * as message from "socket/message";
 import * as disconnect from "socket/disconnect";
+import * as game from "socket/game";
 
 const handlers = Object.values({
   ...piece,
@@ -16,6 +17,7 @@ const handlers = Object.values({
   ...lobby,
   ...message,
   ...disconnect,
+  ...game,
 });
 
 export let io;

--- a/src/server/socket/lobbies/handlers.js
+++ b/src/server/socket/lobbies/handlers.js
@@ -15,7 +15,7 @@ export const handlerAddLobby = async (
   socket.emit(LOBBIES.RESPONSE, response);
 
   if (response.type === "success") {
-    socket.join(`${GROUP_DOMAIN}:${lobby.id}`);
+    socket.join(`${GROUP_DOMAIN}:lobby-${lobby.id}`);
 
     eventEmitter.emit(event.lobbies.change, {
       socket,

--- a/src/server/socket/lobby/handlers.js
+++ b/src/server/socket/lobby/handlers.js
@@ -12,7 +12,7 @@ export const handlerSubscribeLobby = async (socket, { playerId, lobbyId }) => {
   socket.emit(LOBBY.RESPONSE, response);
 
   if (response.type === "success") {
-    socket.join(`${GROUP_DOMAIN}:${lobbyId}`);
+    socket.join(`${GROUP_DOMAIN}:lobby-${lobbyId}`);
 
     eventEmitter.emit(event.lobby.change, {
       socket,
@@ -33,7 +33,7 @@ export const handlerUnsubscribeLobby = async (
   socket.emit(LOBBY.RESPONSE, response);
 
   if (response.type === "success") {
-    socket.leave(`${GROUP_DOMAIN}:${lobbyId}`);
+    socket.leave(`${GROUP_DOMAIN}:lobby-${lobbyId}`);
 
     eventEmitter.emit(event.lobby.change, {
       socket,

--- a/src/server/socket/lobby/handlers.js
+++ b/src/server/socket/lobby/handlers.js
@@ -1,6 +1,6 @@
 import { logerror, loginfo } from "utils/log";
 import { getPlayer } from "storage/players";
-import { joinLobby, leaveLobby } from "storage/lobbies";
+import { joinLobby, leaveLobby, readyLobby } from "storage/lobbies";
 import { LOBBY } from "../../../config/actions/lobby";
 import GROUP_DOMAIN from "../../../config/actions/group";
 import eventEmitter from "listeners";
@@ -43,5 +43,23 @@ export const handlerUnsubscribeLobby = async (
     eventEmitter.emit(event.lobbies.change, {
       socket,
     });
+  }
+};
+
+export const handlerReadyLobby = async (socket, { playerId, lobbyId }) => {
+  const response = await readyLobby(playerId, lobbyId);
+  socket.emit(LOBBY.RESPONSE, response);
+
+  if (response.type === "success") {
+    // socket.leave(`${GROUP_DOMAIN}:${lobbyId}`);
+
+    eventEmitter.emit(event.lobby.change, {
+      socket,
+      lobbyId,
+    });
+
+    // eventEmitter.emit(event.lobbies.change, {
+    //   socket,
+    // });
   }
 };

--- a/src/server/socket/lobby/index.js
+++ b/src/server/socket/lobby/index.js
@@ -2,10 +2,12 @@ import { createEvent } from "socket/helpers/socket";
 import {
   validationSubscribeLobby,
   validationUnsubscribeLobby,
+  validationReadyLobby,
 } from "socket/lobby/schemas";
 import {
   handlerSubscribeLobby,
   handlerUnsubscribeLobby,
+  handlerReadyLobby,
 } from "socket/lobby/handlers";
 import { LOBBY } from "./../../../config/actions/lobby";
 
@@ -19,4 +21,10 @@ export const unsubscribeLobby = createEvent(
   LOBBY.UNSUBSCRIBE,
   validationUnsubscribeLobby,
   handlerUnsubscribeLobby,
+);
+
+export const readyLobby = createEvent(
+  LOBBY.READY,
+  validationReadyLobby,
+  handlerReadyLobby,
 );

--- a/src/server/socket/lobby/schemas.js
+++ b/src/server/socket/lobby/schemas.js
@@ -9,3 +9,8 @@ export const validationSubscribeLobby = {
   lobbyId: Joi.string().required().description("The id of the lobby"),
   playerId: Joi.string().required().description("The id of the player"),
 };
+
+export const validationReadyLobby = {
+  lobbyId: Joi.string().required().description("The id of the lobby"),
+  playerId: Joi.string().required().description("The id of the player"),
+};

--- a/src/server/socket/message/handlers.js
+++ b/src/server/socket/message/handlers.js
@@ -3,10 +3,13 @@ import { nanoid } from "nanoid";
 import eventEmitter from "listeners";
 import event from "listeners/events";
 
-export const handlerSendMessage = async (socket, { message, sender }) => {
+export const handlerSendMessage = async (
+  socket,
+  { message, sender, lobbyId },
+) => {
   const messageObject = { id: nanoid(), message: message, sender: sender };
   eventEmitter.emit(event.message.new, {
-    socket,
+    lobbyId,
     messageObject,
   });
 };

--- a/src/server/storage/game.js
+++ b/src/server/storage/game.js
@@ -1,11 +1,11 @@
 import { getComplexObjectFromRedis, setComplexObjectToRedis } from "storage";
 
-export const getGame = async (id) => {
-  return (await getComplexObjectFromRedis(`game-${id}`)) ?? {};
-};
-
 export const setGame = async (game) => {
   return await setComplexObjectToRedis(`game-${game.id}`, game);
+};
+
+export const getGame = async (id) => {
+  return (await getComplexObjectFromRedis(`game-${id}`)) ?? {};
 };
 
 export const updateScore = async (gameId, playerId, score) => {

--- a/src/server/storage/game.js
+++ b/src/server/storage/game.js
@@ -10,7 +10,7 @@ export const getGame = async (id) => {
 
 export const updateScore = async (gameId, playerId, score) => {
   const game = await getGame(gameId);
-  if (game === {}) return null;
+  if (Object.keys(game).length === 0) return null;
   const newPlayers = [];
   game.players.forEach((element) => {
     if (element.player.id === playerId) element.score = score;
@@ -22,7 +22,7 @@ export const updateScore = async (gameId, playerId, score) => {
 
 export const setLoser = async (gameId, playerId) => {
   const game = await getGame(gameId);
-  if (game === {}) return null;
+  if (Object.keys(game).length === 0) return null;
   const newPlayers = [];
   game.players.forEach((element) => {
     if (element.player.id === playerId) element.loser = true;

--- a/src/server/storage/game.js
+++ b/src/server/storage/game.js
@@ -1,0 +1,7 @@
+import { getComplexObjectFromRedis, setComplexObjectToRedis } from "storage";
+import Response from "models/response";
+import { PLAYER } from "../../config/actions/player";
+
+export const getGame = async (id) => {
+  return (await getComplexObjectFromRedis(`game-${id}`)) ?? {};
+};

--- a/src/server/storage/game.js
+++ b/src/server/storage/game.js
@@ -1,7 +1,19 @@
 import { getComplexObjectFromRedis, setComplexObjectToRedis } from "storage";
 import Response from "models/response";
 import { PLAYER } from "../../config/actions/player";
+import { LOBBIES } from "../../config/actions/lobbies";
+import { LOBBY } from "../../config/actions/lobby";
+import { GAME } from "../../config/actions/game";
+import { getLobby } from "./lobbies";
+
+// export const getGames = async () => {
+//   return (await getComplexObjectFromRedis(`games`)) ?? {};
+// };
 
 export const getGame = async (id) => {
   return (await getComplexObjectFromRedis(`game-${id}`)) ?? {};
+};
+
+export const setGame = async (game) => {
+  return await setComplexObjectToRedis(`game-${game.id}`, game);
 };

--- a/src/server/storage/game.js
+++ b/src/server/storage/game.js
@@ -34,7 +34,7 @@ export const setLoser = async (gameId, playerId) => {
 
 export const checkForWinner = async (gameId) => {
   const game = await getGame(gameId);
-  if (game === {}) return null;
+  if (Object.keys(game).length === 0) return null;
 
   const players = game.players;
 

--- a/src/server/storage/game.js
+++ b/src/server/storage/game.js
@@ -17,3 +17,27 @@ export const getGame = async (id) => {
 export const setGame = async (game) => {
   return await setComplexObjectToRedis(`game-${game.id}`, game);
 };
+
+export const updateScore = async (gameId, playerId, score) => {
+  const game = await getGame(gameId);
+  if (game === {}) return null;
+  const newPlayers = [];
+  game.players.forEach((element) => {
+    if (element.player.id === playerId) element.score = score;
+    newPlayers.push(element);
+  });
+  game.players = newPlayers;
+  return await setComplexObjectToRedis(`game-${game.id}`, game);
+};
+
+export const setLoser = async (gameId, playerId) => {
+  const game = await getGame(gameId);
+  if (game === {}) return null;
+  const newPlayers = [];
+  game.players.forEach((element) => {
+    if (element.player.id === playerId) element.loser = true;
+    newPlayers.push(element);
+  });
+  game.players = newPlayers;
+  return await setComplexObjectToRedis(`game-${game.id}`, game);
+};

--- a/src/server/storage/lobbies.js
+++ b/src/server/storage/lobbies.js
@@ -76,7 +76,7 @@ export const joinLobby = async (player, lobbyId) => {
     return Response.error(LOBBY.SUBSCRIBE, "The lobby is full!");
   }
 
-  lobby.players.push(player);
+  lobby.players.push({ ready: false, player: player });
   lobbies[lobbyId] = lobby;
   await setComplexObjectToRedis("lobbies", lobbies);
 
@@ -107,7 +107,8 @@ export const leaveLobby = async (playerId, lobbyId) => {
 
   const owner = isOwner(lobby, playerId);
   if (owner) {
-    lobby.owner = getNextOwner(lobby.players, playerId);
+    const nextOwner = getNextOwner(lobby.players, playerId);
+    lobby.owner = nextOwner.player;
     /* Handle info on front? */
   }
 
@@ -147,13 +148,13 @@ const isLobbyFull = (lobby) => {
 
 const playerIsOnLobbyBySocketId = (lobbies, socketId) => {
   return Object.keys(lobbies).some((key) =>
-    lobbies[key].players.some((player) => player.socketId === socketId),
+    lobbies[key].players.some((el) => el.player.socketId === socketId),
   );
 };
 
 const playerIsOnLobbyByPlayerId = (lobbies, playerId) => {
   return Object.keys(lobbies).some((key) =>
-    lobbies[key].players.some((player) => player.id === playerId),
+    lobbies[key].players.some((el) => el.player.id === playerId),
   );
 };
 
@@ -166,16 +167,16 @@ const isLastPlayerInLobby = (lobby) => {
 };
 
 const deletePlayerFromPlayers = (players, playerId) => {
-  return players.filter((player) => player.id !== playerId);
+  return players.filter((el) => el.player.id !== playerId);
 };
 
 const getNextOwner = (players, playerId) => {
-  return players.find((player) => player.id !== playerId);
+  return players.find((el) => el.player.id !== playerId);
 };
 
 export const getLobbyIdByPlayerId = (lobbies, playerId) => {
   const lobbyId = Object.keys(lobbies).find((key) =>
-    lobbies[key].players.find((player) => player.id === playerId),
+    lobbies[key].players.find((el) => el.player.id === playerId),
   );
   return lobbyId;
 };

--- a/src/server/storage/lobbies.js
+++ b/src/server/storage/lobbies.js
@@ -174,7 +174,7 @@ export const startGame = async (playerId, lobbyId) => {
     return Response.error(GAME.START, "All the players need to be ready!");
   }
 
-  lobbies[lobbyId].isReady = true;
+  lobbies[lobbyId].isPlaying = true;
   await setComplexObjectToRedis("lobbies", lobbies);
 
   return Response.success(GAME.START, {});

--- a/test/server/mocks.js
+++ b/test/server/mocks.js
@@ -56,6 +56,7 @@ export const lobby1mock = {
   id: "1",
   name: "lobby1",
   maxPlayer: 3,
+  isPlaying: false,
   owner: playerObject1mock,
   players: [
     { player: playerObject1mock, ready: false },
@@ -67,6 +68,7 @@ export const lobby2mock = {
   id: "2",
   name: "lobby2",
   maxPlayer: 3,
+  isPlaying: false,
   owner: playerObject3mock,
   players: [
     { player: playerObject3mock, ready: false },

--- a/test/server/mocks.js
+++ b/test/server/mocks.js
@@ -73,3 +73,25 @@ export const lobby2mock = {
     { player: playerObject4mock, ready: false },
   ],
 };
+
+export const game1mock = {
+  id: "1",
+  name: "lobby1",
+  over: false,
+  owner: playerObject1mock,
+  players: [
+    { player: playerObject1mock, score: 0, loser: false },
+    { player: playerObject2mock, score: 0, loser: false },
+  ],
+};
+
+export const game2mock = {
+  id: "2",
+  name: "lobby2",
+  over: false,
+  owner: playerObject3mock,
+  players: [
+    { player: playerObject3mock, score: 0, loser: false },
+    { player: playerObject4mock, score: 0, loser: false },
+  ],
+};

--- a/test/server/mocks.js
+++ b/test/server/mocks.js
@@ -57,7 +57,10 @@ export const lobby1mock = {
   name: "lobby1",
   maxPlayer: 3,
   owner: playerObject1mock,
-  players: [playerObject1mock, playerObject2mock],
+  players: [
+    { player: playerObject1mock, ready: false },
+    { player: playerObject2mock, ready: false },
+  ],
 };
 
 export const lobby2mock = {
@@ -65,5 +68,8 @@ export const lobby2mock = {
   name: "lobby2",
   maxPlayer: 3,
   owner: playerObject3mock,
-  players: [playerObject3mock, playerObject4mock],
+  players: [
+    { player: playerObject3mock, ready: false },
+    { player: playerObject4mock, ready: false },
+  ],
 };

--- a/test/server/socket/socket.test.js
+++ b/test/server/socket/socket.test.js
@@ -73,7 +73,6 @@ describe("Socket tests", () => {
     });
     socketClient.on("players:publish", (response) => {
       socketClient.off("players:publish");
-
       done();
     });
     socketClient.emit("lobbies:subscribe");
@@ -184,7 +183,6 @@ describe("Socket tests", () => {
         expect(response.type).toBe("success");
         expect(response.payload).toEqual({});
         expect(await getLobbies()).toEqual({});
-
         socketClient.off("lobbies:response");
         done();
       }

--- a/test/server/socket/socket.test.js
+++ b/test/server/socket/socket.test.js
@@ -126,6 +126,41 @@ describe("Socket tests", () => {
     });
   });
 
+  test("Should fail to be ready", async (done) => {
+    socketClient.on("lobby:response", async (response) => {
+      expect(response.type).toBe("error");
+      expect(response.reason).toBe("You are the owner!");
+      socketClient.off("lobby:response");
+      done();
+    });
+
+    const playerId = await getPlayerId(socketClient.id);
+    const lobbies = await getLobbies();
+    const lobbyId = Object.keys(lobbies)[0];
+
+    socketClient.emit("lobby:ready", {
+      playerId: playerId,
+      lobbyId: lobbyId,
+    });
+  });
+
+  test("Should send message", async (done) => {
+    socketClient.on("message:publish", (response) => {
+      expect(response.message).toEqual("message");
+      socketClient.off("message:publish");
+      done();
+    });
+
+    const lobbies = await getLobbies();
+    const lobbyId = Object.keys(lobbies)[0];
+
+    socketClient.emit("message:send", {
+      message: "message",
+      player: { name: "player1" },
+      lobbyId: lobbyId,
+    });
+  });
+
   test("Should leave lobby and lobby should be deleted", async (done) => {
     socketClient.on("lobby:response", (response) => {
       expect(response.type).toBe("success");
@@ -194,18 +229,6 @@ describe("Socket tests", () => {
         lobbyId: lobbyId,
       });
     };
-  });
-
-  test("Should send message", (done) => {
-    socketClient.on("message:publish", (response) => {
-      expect(response.message).toEqual("message");
-      socketClient.off("message:publish");
-      done();
-    });
-    socketClient.emit("message:send", {
-      message: "message",
-      player: { name: "player1" },
-    });
   });
 
   test("Should get new pieces", (done) => {

--- a/test/server/socket/socket.test.js
+++ b/test/server/socket/socket.test.js
@@ -1,15 +1,11 @@
 import redismock from "redis-mock";
 import socketIOClient from "socket.io-client";
-import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
+import { setRedis, quitRedis } from "storage";
 import { getPlayerId, getPlayer } from "../../../src/server/storage/players";
-import {
-  getLobbyIdByPlayerId,
-  getLobbies,
-} from "../../../src/server/storage/lobbies";
+import { getLobbies } from "../../../src/server/storage/lobbies";
 import runHttpServer, { quitHttpServer } from "httpserver";
 import runSocketIo, { quitSocketIo } from "socket";
 import { promiseTimeout } from "utils/promise";
-import { lobby1mock, lobby2mock } from "../mocks";
 
 let socketClient;
 
@@ -139,6 +135,23 @@ describe("Socket tests", () => {
 
     socketClient.emit("lobby:ready", {
       playerId: playerId,
+      lobbyId: lobbyId,
+    });
+  });
+
+  test("Should fail to start game", async (done) => {
+    socketClient.on("game:response", (response) => {
+      expect(response.type).toBe("error");
+      socketClient.off("game:response");
+      done();
+    });
+
+    const playerId = await getPlayerId(socketClient.id);
+    const lobbies = await getLobbies();
+    const lobbyId = Object.keys(lobbies)[0];
+
+    socketClient.emit("game:start", {
+      ownerId: playerId,
       lobbyId: lobbyId,
     });
   });

--- a/test/server/store/game/checkForWinner.test.js
+++ b/test/server/store/game/checkForWinner.test.js
@@ -13,7 +13,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  deleteKeyFromRedis("lobbies");
+  deleteKeyFromRedis(`game-${game1mock.id}`);
 });
 
 describe("checkForWinner function", () => {

--- a/test/server/store/game/checkForWinner.test.js
+++ b/test/server/store/game/checkForWinner.test.js
@@ -1,0 +1,57 @@
+import redismock from "redis-mock";
+import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
+import { checkForWinner, setGame } from "storage/game";
+import { game1mock } from "../../mocks";
+import { deepCopy } from "helpers/functional";
+
+beforeAll(() => {
+  setRedis(redismock.createClient());
+});
+
+afterAll(() => {
+  quitRedis();
+});
+
+beforeEach(() => {
+  deleteKeyFromRedis("lobbies");
+});
+
+describe("checkForWinner function", () => {
+  test("Should return null : 2 players still playing", async () => {
+    const game = deepCopy(game1mock);
+    await setGame(game);
+
+    expect(await checkForWinner(game.id)).toEqual(null);
+  });
+
+  test("Should return null : 1 player still playing but low score", async () => {
+    const game = deepCopy(game1mock);
+    game.players[0].loser = true;
+    game.players[0].score = 200;
+    game.players[1].score = 100;
+    await setGame(game);
+
+    expect(await checkForWinner(game.id)).toEqual(null);
+  });
+
+  test("Should return winner : 1 player still playing and best score", async () => {
+    const game = deepCopy(game1mock);
+    game.players[0].loser = true;
+    game.players[0].score = 100;
+    game.players[1].score = 200;
+    await setGame(game);
+
+    expect(await checkForWinner(game.id)).toEqual(game.players[1]);
+  });
+
+  test("Should return winner : no players playing, best score", async () => {
+    const game = deepCopy(game1mock);
+    game.players[0].loser = true;
+    game.players[1].loser = true;
+    game.players[0].score = 100;
+    game.players[1].score = 200;
+    await setGame(game);
+
+    expect(await checkForWinner(game.id)).toEqual(game.players[1]);
+  });
+});

--- a/test/server/store/game/getGame.test.js
+++ b/test/server/store/game/getGame.test.js
@@ -1,0 +1,29 @@
+import redismock from "redis-mock";
+import { setGame, getGame } from "storage/game";
+import { quitRedis, setRedis, deleteKeyFromRedis } from "storage";
+import { game1mock, game2mock } from "../../mocks";
+
+beforeAll(() => {
+  setRedis(redismock.createClient());
+});
+
+afterAll(() => {
+  deleteKeyFromRedis(`game-${game1mock.id}`);
+  quitRedis();
+});
+
+describe("getGame function", () => {
+  test("No game, should return {}", async () => {
+    expect(await getGame(game1mock.id)).toEqual({});
+  });
+
+  test("game1 added, should return a Game", async () => {
+    await setGame(game1mock);
+
+    expect(await getGame(game1mock.id)).toEqual(game1mock);
+  });
+
+  test("game2 not added, should return {}", async () => {
+    expect(await getGame(game2mock.id)).toEqual({});
+  });
+});

--- a/test/server/store/game/setLoser.test.js
+++ b/test/server/store/game/setLoser.test.js
@@ -1,0 +1,36 @@
+import redismock from "redis-mock";
+import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
+import { setLoser, setGame, getGame } from "storage/game";
+import { game1mock } from "../../mocks";
+
+beforeAll(() => {
+  setRedis(redismock.createClient());
+});
+
+afterAll(() => {
+  quitRedis();
+});
+
+beforeEach(() => {
+  deleteKeyFromRedis(`game-${game1mock.id}`);
+});
+
+describe("setLoser function", () => {
+  test("Should set player to loser", async () => {
+    await setGame(game1mock);
+    const game1 = await getGame(game1mock.id);
+    expect(game1.players[0].loser).toBe(false);
+    expect(game1.players[1].loser).toBe(false);
+
+    await setLoser(game1mock.id, game1mock.players[0].player.id);
+    const game2 = await getGame(game1mock.id);
+    expect(game2.players[0].loser).toBe(true);
+    expect(game2.players[1].loser).toBe(false);
+  });
+
+  test("Should return null : no game", async () => {
+    expect(
+      await setLoser(game1mock.id, game1mock.players[0].player.id),
+    ).toEqual(null);
+  });
+});

--- a/test/server/store/game/updateScore.test.js
+++ b/test/server/store/game/updateScore.test.js
@@ -1,0 +1,36 @@
+import redismock from "redis-mock";
+import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
+import { updateScore, setGame, getGame } from "storage/game";
+import { game1mock } from "../../mocks";
+
+beforeAll(() => {
+  setRedis(redismock.createClient());
+});
+
+afterAll(() => {
+  quitRedis();
+});
+
+beforeEach(() => {
+  deleteKeyFromRedis(`game-${game1mock.id}`);
+});
+
+describe("updateScore function", () => {
+  test("Should set new score", async () => {
+    await setGame(game1mock);
+    const game1 = await getGame(game1mock.id);
+    expect(game1.players[0].score).toEqual(0);
+    expect(game1.players[1].score).toEqual(0);
+
+    await updateScore(game1mock.id, game1mock.players[0].player.id, 200);
+    const game2 = await getGame(game1mock.id);
+    expect(game2.players[0].score).toEqual(200);
+    expect(game2.players[1].score).toEqual(0);
+  });
+
+  test("Should return null : no game", async () => {
+    expect(
+      await updateScore(game1mock.id, game1mock.players[0].player.id, 200),
+    ).toEqual(null);
+  });
+});

--- a/test/server/store/lobbies/clearPlayerFromLobbies.test.js
+++ b/test/server/store/lobbies/clearPlayerFromLobbies.test.js
@@ -40,9 +40,9 @@ describe("clearPlayerFromLobbies function", () => {
     await pushLobby(lobby1mock, lobby1mock.owner.socketId);
     await pushLobby(lobby2mock, lobby2mock.owner.socketId);
 
-    expect(await clearPlayerFromLobbies(lobby1mock.players[1].id)).toEqual(
-      lobby1mock.id,
-    );
+    expect(
+      await clearPlayerFromLobbies(lobby1mock.players[1].player.id),
+    ).toEqual(lobby1mock.id);
   });
 
   test("Should return null and get error from leaveLobby", async () => {

--- a/test/server/store/lobbies/joinLobby.test.js
+++ b/test/server/store/lobbies/joinLobby.test.js
@@ -28,7 +28,7 @@ describe("joinLobby function", () => {
     await pushLobby(lobby1mock, lobby1mock.owner.socketId);
 
     const lobby = deepCopy(lobby1mock);
-    lobby.players.push(playerObject3mock);
+    lobby.players.push({ player: playerObject3mock, ready: false });
 
     expect(await joinLobby(playerObject3mock, lobby1mock.id)).toEqual(
       Response.success(LOBBY.SUBSCRIBE, lobby),
@@ -61,7 +61,7 @@ describe("joinLobby function", () => {
     await pushLobby(lobby1mock, lobby1mock.owner.socketId);
 
     const lobby = deepCopy(lobby1mock);
-    lobby.players.push(playerObject3mock);
+    lobby.players.push({ player: playerObject3mock, ready: false });
 
     expect(await joinLobby(playerObject3mock, lobby1mock.id)).toEqual(
       Response.success(LOBBY.SUBSCRIBE, lobby),

--- a/test/server/store/lobbies/leaveLobby.test.js
+++ b/test/server/store/lobbies/leaveLobby.test.js
@@ -23,9 +23,9 @@ describe("leaveLobby function", () => {
     await pushLobby(lobby1mock, lobby1mock.owner.socketId);
     await pushLobby(lobby2mock, lobby2mock.owner.socketId);
 
-    expect(await leaveLobby(lobby1mock.players[1].id, lobby1mock.id)).toEqual(
-      Response.success(LOBBY.UNSUBSCRIBE, {}),
-    );
+    expect(
+      await leaveLobby(lobby1mock.players[1].player.id, lobby1mock.id),
+    ).toEqual(Response.success(LOBBY.UNSUBSCRIBE, {}));
   });
 
   test("No lobby : Should return an Error response `Lobby doesn't exists`", async () => {
@@ -37,9 +37,9 @@ describe("leaveLobby function", () => {
   });
 
   test("No lobbies : Should return an Error response `Lobby doesn't exists`", async () => {
-    expect(await leaveLobby(lobby1mock.players[1].id, lobby1mock.id)).toEqual(
-      Response.error(LOBBY.UNSUBSCRIBE, "Lobby doesn't exists!"),
-    );
+    expect(
+      await leaveLobby(lobby1mock.players[1].player.id, lobby1mock.id),
+    ).toEqual(Response.error(LOBBY.UNSUBSCRIBE, "Lobby doesn't exists!"));
   });
 
   test("Should return a Success response", async () => {
@@ -49,9 +49,9 @@ describe("leaveLobby function", () => {
       Response.success(LOBBY.UNSUBSCRIBE, {}),
     );
 
-    expect(await leaveLobby(lobby1mock.players[1].id, lobby1mock.id)).toEqual(
-      Response.success(LOBBY.UNSUBSCRIBE, {}),
-    );
+    expect(
+      await leaveLobby(lobby1mock.players[1].player.id, lobby1mock.id),
+    ).toEqual(Response.success(LOBBY.UNSUBSCRIBE, {}));
   });
 
   test("Should return an Error response `last but not owner`", async () => {
@@ -77,6 +77,6 @@ describe("leaveLobby function", () => {
 
     const lobbies = await getLobbies();
 
-    expect(lobbies[lobby.id].owner.id).toEqual(lobby1mock.players[1].id);
+    expect(lobbies[lobby.id].owner.id).toEqual(lobby1mock.players[1].player.id);
   });
 });

--- a/test/server/store/lobbies/readyLobby.test.js
+++ b/test/server/store/lobbies/readyLobby.test.js
@@ -1,0 +1,64 @@
+import redismock from "redis-mock";
+import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
+import Response from "models/response";
+import { LOBBY } from "../../../../src/config/actions/lobby";
+import { readyLobby, pushLobby } from "storage/lobbies";
+import {
+  lobby1mock,
+  lobby2mock,
+  playerObject3mock,
+  playerObject4mock,
+} from "../../mocks";
+import { deepCopy } from "helpers/functional";
+
+beforeAll(() => {
+  setRedis(redismock.createClient());
+});
+
+afterAll(() => {
+  quitRedis();
+});
+
+beforeEach(() => {
+  deleteKeyFromRedis("lobbies");
+});
+
+describe("readyLobby function", () => {
+  test("Should return a Success response", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(
+      await readyLobby(lobby1mock.players[1].player.id, lobby1mock.id),
+    ).toEqual(Response.success(LOBBY.READY, {}));
+  });
+
+  test("Should return an Error response `You are not in this lobby!`", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(await readyLobby(playerObject3mock.id, lobby1mock.id)).toEqual(
+      Response.error(LOBBY.READY, "You are not in this lobby!"),
+    );
+  });
+
+  test("No lobbies : should return an Error response `Lobby doesn't exists!`", async () => {
+    expect(
+      await readyLobby(lobby1mock.players[1].player.id, lobby1mock.id),
+    ).toEqual(Response.error(LOBBY.READY, "Lobby doesn't exists!"));
+  });
+
+  test("No lobby : should return an Error response `Lobby doesn't exists!`", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(
+      await readyLobby(lobby1mock.players[1].player.id, lobby2mock.id),
+    ).toEqual(Response.error(LOBBY.READY, "Lobby doesn't exists!"));
+  });
+
+  test("Should return an Error response `You are the owner!`", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(
+      await readyLobby(lobby1mock.players[0].player.id, lobby1mock.id),
+    ).toEqual(Response.error(LOBBY.READY, "You are the owner!"));
+  });
+});

--- a/test/server/store/lobbies/readyLobby.test.js
+++ b/test/server/store/lobbies/readyLobby.test.js
@@ -3,13 +3,7 @@ import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
 import Response from "models/response";
 import { LOBBY } from "../../../../src/config/actions/lobby";
 import { readyLobby, pushLobby } from "storage/lobbies";
-import {
-  lobby1mock,
-  lobby2mock,
-  playerObject3mock,
-  playerObject4mock,
-} from "../../mocks";
-import { deepCopy } from "helpers/functional";
+import { lobby1mock, lobby2mock, playerObject3mock } from "../../mocks";
 
 beforeAll(() => {
   setRedis(redismock.createClient());

--- a/test/server/store/lobbies/startGame.test.js
+++ b/test/server/store/lobbies/startGame.test.js
@@ -1,0 +1,76 @@
+import redismock from "redis-mock";
+import { setRedis, quitRedis, deleteKeyFromRedis } from "storage";
+import Response from "models/response";
+import { GAME } from "../../../../src/config/actions/game";
+import { startGame, pushLobby } from "storage/lobbies";
+import {
+  lobby1mock,
+  lobby2mock,
+  playerObject3mock,
+  playerObject4mock,
+} from "../../mocks";
+import { deepCopy } from "helpers/functional";
+
+beforeAll(() => {
+  setRedis(redismock.createClient());
+});
+
+afterAll(() => {
+  quitRedis();
+});
+
+beforeEach(() => {
+  deleteKeyFromRedis("lobbies");
+});
+
+describe("startGame function", () => {
+  test("Should return a Success response", async () => {
+    const lobby = deepCopy(lobby1mock);
+    lobby.players[1].ready = true;
+    await pushLobby(lobby, lobby.owner.socketId);
+
+    expect(await startGame(lobby.players[0].player.id, lobby.id)).toEqual(
+      Response.success(GAME.START, {}),
+    );
+  });
+
+  test("Should return an Error response `You need to be at least 2 players!`", async () => {
+    const lobby = deepCopy(lobby1mock);
+    lobby.players.pop();
+    await pushLobby(lobby, lobby.owner.socketId);
+
+    expect(await startGame(lobby.players[0].player.id, lobby.id)).toEqual(
+      Response.error(GAME.START, "You need to be at least 2 players!"),
+    );
+  });
+
+  test("Should return an Error response `All the players need to be ready!`", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(
+      await startGame(lobby1mock.players[0].player.id, lobby1mock.id),
+    ).toEqual(Response.error(GAME.START, "All the players need to be ready!"));
+  });
+
+  test("No lobbies : should return an Error response `Lobby doesn't exists!`", async () => {
+    expect(
+      await startGame(lobby1mock.players[0].player.id, lobby1mock.id),
+    ).toEqual(Response.error(GAME.START, "Lobby doesn't exists!"));
+  });
+
+  test("No lobby : should return an Error response `Lobby doesn't exists!`", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(
+      await startGame(lobby1mock.players[0].player.id, lobby2mock.id),
+    ).toEqual(Response.error(GAME.START, "Lobby doesn't exists!"));
+  });
+
+  test("Should return an Error response `You are not the owner!`", async () => {
+    await pushLobby(lobby1mock, lobby1mock.owner.socketId);
+
+    expect(
+      await startGame(lobby1mock.players[1].player.id, lobby1mock.id),
+    ).toEqual(Response.error(GAME.START, "You are not the owner!"));
+  });
+});


### PR DESCRIPTION
See #20 

This PR includes the game management server side.

You should now be able to call from client :

- **lobby:ready**(playerId, lobbyId) => put the player to the state "ready", gives a succes or an error with **lobby:response** updates the players on lobby with **lobby:publish**
- **game:start**(ownerId, lobbyId) => needs to  be called by the owner, check if the game can start then sends a **game:response** success or error. If success, it will put the lobby in the "isPlaying" state, create a game object, and send a game:started to all of the players of the lobby and put then in a group:game-id
- **game:send_score**(gameId, playerId, score) => sends the score updated to the server, the server will dispatch to the other players with a **game:get_score**(playerId, score) and check asynchronously if there is a winner
- **game:send_board**(gameId, playerId, boardGame) => sends the board updated to the server, the server will dispatch to the other players with a **game:get_board**(playerId, boardGame)
- **game:send_penalty**(gameId, playerId, nbLinePenalty) => sends the penalty to applicate to the other players, the server will dispatch to the other players with a **game:get_penalty**(playerId, nbLinePenalty)
- **game:send_lose**(gameId, playerId) => sends a "lose", the server will put "loser" to true in the game object, dispatch to the other players with a **game:get_lose**(playerId) and check asynchronously if there is a winner

If the server detects a winner, he will delete the game object internally, send a **game:winner**(winner->object of the player) to all the players, then make all the players automatically leave the group:game-id.

To do after :
Handle player disconnection! -> Put them to loser, check winner, send a game:leaver, get him out of group:game-id handle the rest as usual