### PR TITLE
reset response on front after using it

### DIFF
--- a/src/client/pages/lobbies/Lobbies.jsx
+++ b/src/client/pages/lobbies/Lobbies.jsx
@@ -8,7 +8,7 @@ import { StoreContext } from "store";
 import "./Lobbies.scss";
 import { setupSocketRooms } from "store/middleware/sockets";
 import useNavigate from "hooks/useNavigate";
-import { setLobby } from "actions/store";
+import { setLobby, setLobbyResponse } from "actions/store";
 import { toast } from "react-toastify";
 import { LOBBY } from "../../../config/actions/lobby";
 import { socket } from "store/middleware/sockets";
@@ -48,6 +48,7 @@ export default function Lobbies() {
         notify(state?.lobbyResponse?.reason);
       } else if (state.lobbyResponse.type === "success") {
         dispatch(setLobby(state.lobbyResponse.payload));
+        dispatch(setLobbyResponse({}));
         navigate(
           `/rooms/${state.lobbyResponse.payload.name}[${state.player.name}]`,
         );

--- a/src/client/pages/lobby/Lobby.jsx
+++ b/src/client/pages/lobby/Lobby.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import FlexBox from "components/flexbox/FlexBox";
 import { LOBBY } from "../../../config/actions/lobby";
 import { LOBBIES } from "../../../config/actions/lobbies";
-import { setLobby } from "actions/store";
+import { setLobby, setLobbiesResponse, setLobbyResponse } from "actions/store";
 import useNavigate from "hooks/useNavigate";
 import "./Lobby.scss";
 import { socket } from "store/middleware/sockets";
@@ -18,6 +18,7 @@ export default function Lobby({ open, close, state, dispatch }) {
         notify(state?.lobbyResponse?.reason);
       } else if (state.lobbyResponse.type === "success") {
         dispatch(setLobby({}));
+        dispatch(setLobbyResponse({}));
         close();
         navigate("/rooms");
       }
@@ -42,6 +43,7 @@ export default function Lobby({ open, close, state, dispatch }) {
         notify(state?.lobbiesResponse?.reason);
       } else if (state.lobbiesResponse.type === "success") {
         dispatch(setLobby({}));
+        dispatch(setLobbiesResponse({}));
         close();
         navigate("/rooms");
       }


### PR DESCRIPTION
Concerning #60 :
What's happening is that the lobbiesResponse for the delete action has not been reset after the user deleted his own lobby.
Si when he tries to join a new lobby after that, he gets redirected, but the useEffect for lobbiesResponse is triggered, he sees the last reponse (lobbies:delete, success) and do the action (deletete lobby, close(), and navigate to room).
I reset the lobbiesResponse with a setLobbyResponse({}).
We might need to check them all and add a clear system.
Cheers
closes #60 